### PR TITLE
Fix parsing of current track title

### DIFF
--- a/integrate.js
+++ b/integrate.js
@@ -169,7 +169,7 @@ WebApp.update = function()
     
     try
     {
-        elm = document.getElementById('player-song-title').firstChild;
+        elm = document.querySelector("#playerSongInfo #currently-playing-title");
         track.title = elm.innerText || elm.textContent;
     }
     catch(e)


### PR DESCRIPTION
Fixes now-playing track title for Google play music, fixing display for nuvolaplayer3ctl as well as desktop notifications.
