### PR TITLE
Fix parsing of current track album art

### DIFF
--- a/integrate.js
+++ b/integrate.js
@@ -160,7 +160,7 @@ WebApp.update = function()
     var track = {};
     try
     {
-        track.artLocation = document.getElementById('playingAlbumArt').src.replace("=s90-", "=s500-");
+        track.artLocation = document.querySelector("#playerSongInfo #playerBarArt").src.replace("=s90-", "=s500-");
     }
     catch(e)
     {


### PR DESCRIPTION
Fixes the problem of current playing track album art not showing for Google Play Music.
- Author: hansamuE hansamuE@gmail.com
