### PR TITLE
symlink scalable icon to proper destination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ install: $(LICENSES) $(INSTALL_FILES) $(PNG_ICONS) $(SCALABLE_ICON)
 	
 	# Create symlinks to icons
 	mkdir -pv $(DEST)/../../icons/hicolor/scalable/apps || true
-	ln -s -f -v -T ../../../../$(APP_ID)/$(SCALABLE_ICON) \
+	ln -s -f -v -T ../../../../nuvolaplayer3/web_apps/$(APP_ID)/$(SCALABLE_ICON) \
 		$(DEST)/../../icons/hicolor/scalable/apps/nuvolaplayer3_$(APP_ID).svg;
 	for size in $(ICON_SIZES); do \
 		mkdir -pv $(DEST)/../../icons/hicolor/$${size}x$${size}/apps || true ; \


### PR DESCRIPTION
Currently it makes a broken symlink on Arch, presumably everywhere else too. I assume this also applies to other integrations — to simplify handling those, [this gist](https://gist.github.com/Celti/8f17fac482777b376723749c9ff8a5d9) should apply cleanly to all of them.
