### PR TITLE
Hack-fix SVG conversion for Arch Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,10 @@
 
 # Service integration id
 APP_ID = google_play_music
+# Image converter to use (rsvg-convert or lasem-render)
+SVG_CONVERT ?= rsvg-convert
 # Dependencies
-DEPS = rsvg-convert
+DEPS = $(SVG_CONVERT)
 # Default installation destination
 DEST ?= $(HOME)/.local/share/nuvolaplayer3/web_apps
 # Sizes of the whole icon set
@@ -57,35 +59,35 @@ $(ICONS_DIR):
 	
 # Generate icon 16
 $(ICONS_DIR)/16.png: $(SOURCE_ICON_XS) | $(ICONS_DIR)
-	rsvg-convert -z 1 $< -o $@
+	$(SVG_CONVERT) -z 1 $< -o $@
 
 # Generate icon 22	
 $(ICONS_DIR)/22.png : $(SOURCE_ICON_XS) | $(ICONS_DIR)
-	rsvg-convert -z 1.375 $< -o $@
+	$(SVG_CONVERT) -z 1.375 $< -o $@
 
 # Generate icon 24	
 $(ICONS_DIR)/24.png : $(SOURCE_ICON_XS) | $(ICONS_DIR)
-	rsvg-convert -z 1.5 $< -o $@
+	$(SVG_CONVERT) -z 1.5 $< -o $@
 
 # Generate icon 32	
 $(ICONS_DIR)/32.png : $(SOURCE_ICON_SM) | $(ICONS_DIR)
-	rsvg-convert -z 1 $< -o $@
+	$(SVG_CONVERT) -z 1 $< -o $@
 
 # Generate icon 48
 $(ICONS_DIR)/48.png : $(SOURCE_ICON_SM) | $(ICONS_DIR)
-	rsvg-convert -z 1.5 $< -o $@
+	$(SVG_CONVERT) -z 1.5 $< -o $@
 
 # Generate icon 64
 $(ICONS_DIR)/64.png : $(SOURCE_ICON) | $(ICONS_DIR)
-	rsvg-convert -z 0.125 $< -o $@
+	$(SVG_CONVERT) -z 0.125 $< -o $@
 
 # Generate icon 128
 $(ICONS_DIR)/128.png : $(SOURCE_ICON) | $(ICONS_DIR)
-	rsvg-convert -z 0.25 $< -o $@
+	$(SVG_CONVERT) -z 0.25 $< -o $@
 
 # Generate icon 256
 $(ICONS_DIR)/256.png : $(SOURCE_ICON) | $(ICONS_DIR)
-	rsvg-convert -z 0.5 $< -o $@
+	$(SVG_CONVERT) -z 0.5 $< -o $@
 
 # Copy scalable icon
 $(SCALABLE_ICON) : $(SOURCE_ICON) | $(ICONS_DIR)

--- a/Makefile
+++ b/Makefile
@@ -57,27 +57,35 @@ $(ICONS_DIR):
 	
 # Generate icon 16
 $(ICONS_DIR)/16.png: $(SOURCE_ICON_XS) | $(ICONS_DIR)
-	rsvg-convert -w 16 -h 16 $< -o $@
+	rsvg-convert -z 1 $< -o $@
 
 # Generate icon 22	
 $(ICONS_DIR)/22.png : $(SOURCE_ICON_XS) | $(ICONS_DIR)
-	rsvg-convert -w 22 -h 22 $< -o $@
+	rsvg-convert -z 1.375 $< -o $@
 
 # Generate icon 24	
 $(ICONS_DIR)/24.png : $(SOURCE_ICON_XS) | $(ICONS_DIR)
-	rsvg-convert -w 24 -h 24 $< -o $@
+	rsvg-convert -z 1.5 $< -o $@
 
 # Generate icon 32	
 $(ICONS_DIR)/32.png : $(SOURCE_ICON_SM) | $(ICONS_DIR)
-	rsvg-convert -w 32 -h 32 $< -o $@
+	rsvg-convert -z 1 $< -o $@
 
 # Generate icon 48
 $(ICONS_DIR)/48.png : $(SOURCE_ICON_SM) | $(ICONS_DIR)
-	rsvg-convert -w 48 -h 48 $< -o $@
+	rsvg-convert -z 1.5 $< -o $@
 
-# Generate icons 64 128 256
-$(ICONS_DIR)/%.png : $(SOURCE_ICON) | $(ICONS_DIR)
-	rsvg-convert -w $* -h $* $< -o $@
+# Generate icon 64
+$(ICONS_DIR)/64.png : $(SOURCE_ICON) | $(ICONS_DIR)
+	rsvg-convert -z 0.125 $< -o $@
+
+# Generate icon 128
+$(ICONS_DIR)/128.png : $(SOURCE_ICON) | $(ICONS_DIR)
+	rsvg-convert -z 0.25 $< -o $@
+
+# Generate icon 256
+$(ICONS_DIR)/256.png : $(SOURCE_ICON) | $(ICONS_DIR)
+	rsvg-convert -z 0.5 $< -o $@
 
 # Copy scalable icon
 $(SCALABLE_ICON) : $(SOURCE_ICON) | $(ICONS_DIR)


### PR DESCRIPTION
This reworks the Makefile to use zooms instead of dimensions to convert the icons (tested as working with rsvg on Debian Jessie) and further allows specifying an alternate converter — on Arch, lasem-render uses the same syntax (for zooms, anyway — doesn't allow dimensions) and actually _works_, unlike rsvg-convert.

I am fine with maintaining this locally for Arch PKGBUILDs, if necessary, but I don't think there's any harm in adding it to the integrations (I've tried to avoid any such problems).

As with my other PR, this is a problem for all integrations: here is [a gist](https://gist.github.com/Celti/5d8afed91b9794c9d6bcc0a9c7384e82) with a patch that should apply cleanly to all of them (tested on google-play and owncloud-music).
